### PR TITLE
Small improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ quick-error = "1.2.2"
 [dev-dependencies]
 env_logger = "0.6.0"
 hamcrest2 = "0.2.3"
+maplit = "1.0.1"

--- a/examples/discover_peers.rs
+++ b/examples/discover_peers.rs
@@ -21,6 +21,7 @@ use futures::Stream;
 use get_if_addrs::{get_if_addrs, IfAddr};
 use libredrop_net::discover_peers;
 use safe_crypto::gen_encrypt_keypair;
+use std::collections::HashSet;
 use std::io;
 use std::net::{SocketAddr, SocketAddrV4};
 use tokio::runtime::current_thread::Runtime;
@@ -43,7 +44,7 @@ fn main() -> io::Result<()> {
 }
 
 /// Construct a list of fake listening addresses.
-fn our_addrs(with_port: u16) -> io::Result<Vec<SocketAddr>> {
+fn our_addrs(with_port: u16) -> io::Result<HashSet<SocketAddr>> {
     let interfaces = get_if_addrs()?;
     let addrs = interfaces
         .iter()

--- a/examples/peer_discovery_server.rs
+++ b/examples/peer_discovery_server.rs
@@ -20,6 +20,7 @@ extern crate safe_crypto;
 use get_if_addrs::{get_if_addrs, IfAddr};
 use libredrop_net::DiscoveryServer;
 use safe_crypto::gen_encrypt_keypair;
+use std::collections::HashSet;
 use std::io;
 use std::net::{SocketAddr, SocketAddrV4};
 use tokio::prelude::Future;
@@ -42,7 +43,7 @@ fn main() -> io::Result<()> {
 }
 
 /// Construct a list of fake listening addresses.
-fn our_addrs(with_port: u16) -> io::Result<Vec<SocketAddr>> {
+fn our_addrs(with_port: u16) -> io::Result<HashSet<SocketAddr>> {
     let interfaces = get_if_addrs()?;
     let addrs = interfaces
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ extern crate void;
 #[cfg(test)]
 #[macro_use]
 extern crate hamcrest2;
+#[cfg(test)]
+#[macro_use]
+extern crate maplit;
 
 mod listener;
 mod message;
@@ -35,7 +38,7 @@ mod utils;
 
 pub use crate::listener::ConnectionListener;
 pub use crate::message::Message;
-pub use crate::peer::{connect_with, ConnectError, Connection, ConnectionError, PeerInfo};
+pub use crate::peer::{connect_first_ok, ConnectError, Connection, ConnectionError, PeerInfo};
 pub use crate::peer_discovery::{discover_peers, shout_for_peers, DiscoveryError, DiscoveryServer};
 
 use maidsafe_utilities::serialisation::SerialisationError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 //! platforms. So it enables you to easilly exchange files between Linux <--> Android, iOS <-->
 //! Windows, etc.
 
+#![deny(bare_trait_objects)]
+#![allow(clippy::implicit_hasher)]
+
 extern crate future_utils;
 extern crate futures;
 extern crate get_if_addrs;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -124,7 +124,7 @@ impl Stream for ConnectionListener {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::peer::connect_with;
+    use crate::peer::connect_first_ok;
     use crate::utils::ipv4_addr;
     use safe_crypto::gen_encrypt_keypair;
     use tokio::runtime::current_thread::Runtime;
@@ -155,7 +155,7 @@ mod tests {
 
             let (our_pk, our_sk) = gen_encrypt_keypair();
             let listener_info = unwrap!(addr_rx.recv());
-            let task = connect_with(&listener_info, our_sk, our_pk);
+            let task = connect_first_ok(hashset! {listener_info}, our_sk, our_pk);
             let mut evloop = unwrap!(Runtime::new());
             unwrap!(evloop.block_on(task));
 

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -1,8 +1,10 @@
 #[macro_use]
 extern crate unwrap;
+#[macro_use]
+extern crate maplit;
 
 use futures::{stream, Future, Sink, Stream};
-use libredrop_net::{connect_with, ConnectionError, ConnectionListener, Message, PeerInfo};
+use libredrop_net::{connect_first_ok, ConnectionError, ConnectionListener, Message, PeerInfo};
 use safe_crypto::gen_encrypt_keypair;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use tokio::runtime::current_thread::Runtime;
@@ -19,7 +21,7 @@ fn exchange_data() {
         .map(|(conn_opt, _listener)| unwrap!(conn_opt))
         .map_err(|(e, _listener)| panic!(e));
     let (our_pk, our_sk) = gen_encrypt_keypair();
-    let connect = connect_with(&listener_info, our_sk, our_pk).join(accept_conn);
+    let connect = connect_first_ok(hashset! {listener_info}, our_sk, our_pk).join(accept_conn);
 
     let mut evloop = unwrap!(Runtime::new());
     let (conn1, conn2) = unwrap!(evloop.block_on(connect));


### PR DESCRIPTION
1. Replace `connect_with()` with `connect_first_ok()` which attempts multiple connections concurrently.
2. Use HashSet instead of Vec to hold peer listener addresses.