### PR TITLE
Fix connection concurrency

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -75,7 +75,7 @@ pub fn connect_first_ok(
     our_pk: PublicEncryptKey,
 ) -> impl Future<Item = Connection, Error = ConnectError> {
     stream::iter_ok(peers)
-        .and_then(|peer| TcpStream::connect(&peer.addr).map(|stream| Ok((stream, peer))))
+        .map(|peer| TcpStream::connect(&peer.addr).map(|stream| (stream, peer)))
         .buffer_unordered(16)
         .first_ok()
         .map_err(ConnectError::AllAttemptsFailed)


### PR DESCRIPTION
This little change makes sure multiple connections are executed concurrently.
Before they were executed sequentially one after the other which would result
in sloow connections: if one connection would fail it would take ~2 minutes on
Linux to try the next endpoint.